### PR TITLE
avoid NPE if project directory does not exist; fixes #10

### DIFF
--- a/src/main/java/uk/ac/ic/wlgitbridge/util/Util.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/util/Util.java
@@ -138,12 +138,15 @@ public class Util {
     public static void deleteInDirectoryApartFrom(File directory, String... apartFrom) {
         if (directory != null) {
             Set<String> excluded = new HashSet<String>(Arrays.asList(apartFrom));
-            for (File file : directory.listFiles()) {
-                if (!excluded.contains(file.getName())) {
-                    if (file.isDirectory()) {
-                        deleteInDirectory(file);
+            File [] files = directory.listFiles();
+            if (files != null) {
+                for (File file : files) {
+                    if (!excluded.contains(file.getName())) {
+                        if (file.isDirectory()) {
+                            deleteInDirectory(file);
+                        }
+                        file.delete();
                     }
-                    file.delete();
                 }
             }
         }

--- a/src/test/resources/uk/ac/ic/wlgitbridge/WLGitBridgeIntegrationTest/pushSucceedsAfterRemovingInvalidFiles/invalidState/state.json
+++ b/src/test/resources/uk/ac/ic/wlgitbridge/WLGitBridgeIntegrationTest/pushSucceedsAfterRemovingInvalidFiles/invalidState/state.json
@@ -1,0 +1,34 @@
+[
+	{
+		"project": "testproj",
+		"getDoc": {
+			"versionID": 1,
+			"createdAt": "2014-11-30T18:40:58.123Z",
+			"email": "test@example.com",
+			"name": "Test User"
+		},
+		"getSavedVers": [],
+		"getForVers": [
+			{
+				"versionID": 1,
+				"srcs": [
+                    {
+                    	"content": "content\n",
+                    	"path": "main.tex"
+                    }
+	            ],
+	            "atts": []
+	        }
+		],
+		"push": "success",
+		"postback": {
+			"type": "invalidFiles",
+            "errors": [
+                {
+                    "file": "file1.exe",
+                    "state": "disallowed"
+                }
+            ]
+		}
+	}
+]

--- a/src/test/resources/uk/ac/ic/wlgitbridge/WLGitBridgeIntegrationTest/pushSucceedsAfterRemovingInvalidFiles/invalidState/testproj/main.tex
+++ b/src/test/resources/uk/ac/ic/wlgitbridge/WLGitBridgeIntegrationTest/pushSucceedsAfterRemovingInvalidFiles/invalidState/testproj/main.tex
@@ -1,0 +1,1 @@
+content

--- a/src/test/resources/uk/ac/ic/wlgitbridge/WLGitBridgeIntegrationTest/pushSucceedsAfterRemovingInvalidFiles/validState/state.json
+++ b/src/test/resources/uk/ac/ic/wlgitbridge/WLGitBridgeIntegrationTest/pushSucceedsAfterRemovingInvalidFiles/validState/state.json
@@ -1,0 +1,29 @@
+[
+	{
+		"project": "testproj",
+		"getDoc": {
+			"versionID": 1,
+			"createdAt": "2014-11-30T18:40:58.123Z",
+			"email": "test@example.com",
+			"name": "Test User"
+		},
+		"getSavedVers": [],
+		"getForVers": [
+			{
+				"versionID": 1,
+				"srcs": [
+                    {
+                    	"content": "content\n",
+                    	"path": "main.tex"
+                    }
+	            ],
+	            "atts": []
+	        }
+		],
+		"push": "success",
+	    "postback": {
+	   		"type": "success",
+			"versionID": 2
+	  	}
+	}
+]

--- a/src/test/resources/uk/ac/ic/wlgitbridge/WLGitBridgeIntegrationTest/pushSucceedsAfterRemovingInvalidFiles/validState/testproj/main.tex
+++ b/src/test/resources/uk/ac/ic/wlgitbridge/WLGitBridgeIntegrationTest/pushSucceedsAfterRemovingInvalidFiles/validState/testproj/main.tex
@@ -1,0 +1,1 @@
+content


### PR DESCRIPTION
If the last commit is an empty commit, then the project directory is never created, and we get an NPE in the `Util.deleteInDirectoryApartFrom`.
