### PR TITLE
Anonymous versions

### DIFF
--- a/src/main/java/uk/ac/ic/wlgitbridge/snapshot/getsavedvers/SnapshotInfo.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/snapshot/getsavedvers/SnapshotInfo.java
@@ -32,7 +32,7 @@ public class SnapshotInfo implements Comparable<SnapshotInfo> {
     }
 
     public WLUser getUser() {
-        return user;
+        return user != null ? user : new WLUser();
     }
 
     public String getCreatedAt() {

--- a/src/main/java/uk/ac/ic/wlgitbridge/snapshot/push/PushResult.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/snapshot/push/PushResult.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonObject;
 import uk.ac.ic.wlgitbridge.snapshot.base.Result;
 import uk.ac.ic.wlgitbridge.snapshot.base.Request;
 import uk.ac.ic.wlgitbridge.snapshot.exception.FailedConnectionException;
+import uk.ac.ic.wlgitbridge.util.Util;
 
 /**
  * Created by Winston on 16/11/14.
@@ -28,8 +29,16 @@ public class PushResult extends Result {
 
     @Override
     public void fromJSON(JsonElement json) {
-        JsonObject responseObject = json.getAsJsonObject();
-        String code = responseObject.get("code").getAsString();
+        String code;
+        try {
+            JsonObject responseObject = json.getAsJsonObject();
+            code = responseObject.get("code").getAsString();
+        } catch (Exception e) {
+            Util.serr("Unexpected response from API:");
+            Util.serr(json.toString());
+            Util.serr("End of response");
+            throw e;
+        }
         if (code.equals("accepted")) {
             success = true;
         } else if (code.equals("outOfDate")) {
@@ -38,5 +47,4 @@ public class PushResult extends Result {
             throw new RuntimeException();
         }
     }
-
 }


### PR DESCRIPTION
This fixes a case when de API sends a version without user. There was a
bug allowing to create anonymous versions in the application and we
have to support the old data.

The problem here is that SnapshotInfo classes are inflated from json
via Gson. This method does not call any constructor and, since the json
does not include the ‘user’ key, the bridge crashes because we’re not
expecting null users.

I’m not happy with this fix, but is the minimum solution that does not
affect anything else.